### PR TITLE
Make the player visuals asymmetrical

### DIFF
--- a/Player/Player.tscn
+++ b/Player/Player.tscn
@@ -85,7 +85,7 @@ player_path = NodePath("..")
 [node name="Polygon2D" type="Polygon2D" parent="Sprite"]
 position = Vector2(0, -8)
 color = Color(0.964706, 0.952941, 0.298039, 1)
-polygon = PackedVector2Array(-16, -16, -16, 16, 16, 16, 16, -16)
+polygon = PackedVector2Array(-19, -18, -16.2806, 12.8197, -12.3612, 16, 13.3018, 16, 16, 12.6567, 16, -7.71495, 6, -16)
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Sprite"]
 libraries = {


### PR DESCRIPTION
Make the player's facing direction visible by giving them a spiky trail at the back and rounded "face". Now you can see that the set_direction code is working correctly.

Here's what the new player looks like (facing right):
![image](https://github.com/TheoTheTorch/MOVEMENT-2/assets/43559/69bc407c-2ce6-435e-b52b-a4a456d62c9f)
