### PR TITLE
Fix moving platform code for operating systems without editor support

### DIFF
--- a/Platforms/MovingPlatform.gd
+++ b/Platforms/MovingPlatform.gd
@@ -10,7 +10,7 @@ extends Node2D
 @export var move_to := Vector2(0, -128) : set = set_move_to
 func set_move_to(new_value: Vector2) -> void:
 	move_to = new_value
-	if OS.has_feature("editor") and get_children() != []:
+	if Engine.is_editor_hint() and get_children() != []:
 		for child in get_children():
 			child.position = move_to
 
@@ -20,10 +20,13 @@ func set_move_to(new_value: Vector2) -> void:
 
 func _ready() -> void:
 	set_move_to(move_to)
-	if OS.has_feature("editor") and get_children() != []:
+	
+	if get_children() != []:
 		set_process(false)
 		for child in get_children():
 			start_tween(child)
+
+
 func _process(_delta: float) -> void:
 	queue_redraw()
 


### PR DESCRIPTION
If you built this project for any OS that doesn't support the editor, the platforms would be static and inconsistent with Windows builds or editor debugging sessions.

The issues are two-fold:
- `OS.has_feature("OS")` does not check if the editor is running but checks if the operating system can run the editor in general. This is generally used to check the feature-set of an operating system, not as a runtime environment check. In this case, I believe you want to use `Engine.is_editor_hint()` to check if the script is running in an editor session or not. I could be wrong here so feedback would be nice on what the original intent was.
- AFAIK the `_ready` editor check is unnecessary as we always want to begin the tween, regardless of if we're in or out of the editor. I've removed that editor check but kept the one in `set_move_to` as it seems to relocate the position and will generally only be changed by the editor itself.

Let me know if this causes any unintended side effects on your end. I've tested it pretty thoroughly on my end and noticed no regression  so thought I would upstream. :)