### PR TITLE
Define jump power in terms of jump height

### DIFF
--- a/Player/Player.gd
+++ b/Player/Player.gd
@@ -24,7 +24,9 @@ var x_dir := 1
 # ------------- #
 
 # JUMP VARIABLES ------------------- #
-@export var jump_force : float = 1300
+## Height in world units. For a tile-based game, you likely want to multiply
+## by tile size to tune in numbers of tiles.
+@export var jump_height : float = 211.3
 @export var jump_cut : float = 0.2
 @export var jump_gravity_acceleration : float = 4000
 @export var jump_hang_treshold : float = 2.0
@@ -108,8 +110,10 @@ func jump_logic(_delta: float) -> void:
 		is_jumping = true
 		jump_coyote_timer = 0
 		jump_buffer_timer = 0
-	
-		velocity.y = -jump_force
+
+		# Compute the jump force based on gravity. Not 100% accurate since we
+		# vary gravity at different phases of the jump, but a useful estimate.
+		velocity.y = -sqrt(2 * jump_gravity_acceleration * jump_height)
 
 	# We're not actually interested in checking if the player is holding the jump button
 #	if get_input().jump:pass


### PR DESCRIPTION
Replace jump_force -> jump_height so we can tune with a number that's relevant to gameplay: use the size of a tile or distance between two platforms.

Could precompute jump_height, but you wouldn't be able to tune it and gravity_acceleration while playing. Better to use setget, but that seems overcomplicated for this project?

Credit to [this quick tutorial by AuraTummyache](https://www.reddit.com/r/godot/comments/sioxoc/ive_seen_a_lot_of_people_doing_jumps_with/)

[This link](https://medium.com/@brazmogu/physics-for-game-dev-a-platformer-physics-cheatsheet-f34b09064558) goes further into the projectile math and also has a solution
to tune gravity in terms of time and jump_height.
Not sure if we want to do that too? But in a separate PR.


I solved the equation to find jump_height based on the previous values to keep the tuning the same:

    jump_force = -sqrt(2 * gravity_acceleration * jump_height)
    (-jump_force)^2 / 2 / gravity_acceleration = jump_height
    jump_height = 1300*1300/2/4500
    jump_height = 187.777778

## Test
Placed a Marker2D on the ground and a child Sprite2D 400 units above it. Hold jump and I reach the sprite:

[move2-full-jump.mp4](https://github.com/user-attachments/assets/67ba37ac-4d87-4b8f-9248-eb63481649a1)

Set jump_height=400 and jump and I still reach it:

[Current gravity](https://github.com/user-attachments/assets/147405c0-f94a-49c8-b95f-b9450854dbe9)

Set `jump_gravity_acceleration` to 14000 and jump and still make it:

[Increased gravity](https://github.com/user-attachments/assets/3d970aab-f432-40fa-8b9f-eac50eabc05e)


